### PR TITLE
Close HTTP stream

### DIFF
--- a/stumpwm-weather.lisp
+++ b/stumpwm-weather.lisp
@@ -66,10 +66,11 @@
     ht))
 
 (defun http-get-ia-hash-table (req)
-  (let ((stream (drakma:http-request
-                 req
-                 :want-stream t
-                 :decode-content t)))
+  (with-open-stream (stream
+                     (drakma:http-request
+                      req
+                      :want-stream t
+                      :decode-content t))
     (setf (flexi-streams:flexi-stream-external-format stream) :utf-8)
     (rec-plist-ia-hash-table (yason:parse stream :object-as :plist))))
 


### PR DESCRIPTION
The current code never closes the HTTP request stream to the OpenWeatherMap API. This wraps the parsing code in `with-open-stream` so the stream will be closed properly.

Without this change, stumpwm eventually runs out of open file descriptors, which prevents it from doing a lot of things.